### PR TITLE
Make cards clickable to reveal, move draw button

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,10 @@
         <main>
             <div class="game-board pixel-corners">
                 <div class="card-row">
-                    <div id="known-card" class="card card-back"></div>
+                    <div id="known-card" class="card card-back flippable"></div>
                     <div id="unknown-card" class="card card-back"></div>
                 </div>
                 <div class="btn-row">
-                    <button id="draw-btn">Draw</button>
                     <div class="higher-lower">
                         <button id="higher-btn" class="not-selectable">
                             Higher

--- a/script.js
+++ b/script.js
@@ -50,20 +50,19 @@ function shuffle(array) {
 shuffle(deck);
 
 // Get button and card elements from game board
-const drawButton = document.getElementById("draw-btn");
 const knownCard = document.getElementById("known-card");
-// Make the higher and lower buttons selectable once a card has been drawn
+const unknownCard = document.getElementById("unknown-card");
 const higherBtn = document.getElementById("higher-btn");
 const lowerBtn = document.getElementById("lower-btn");
-// A boolean value to see if a card has been drawn or not
+// A boolean value to see if the knownCard card has been drawn or not
 let knownCardDrawn = false;
 
 // Display the next card when the "Draw" button is clicked
-drawButton.addEventListener("click", function () {
+knownCard.addEventListener("click", function () {
     if (!knownCardDrawn) {
         knownCard.innerHTML = "<h3>" + getnextCard(deck) + "</h3>";
         knownCard.classList.remove("card-back");
-        drawButton.classList.add("not-selectable");
+        knownCard.classList.remove("flippable");
         higherBtn.classList.remove("not-selectable");
         lowerBtn.classList.remove("not-selectable");
     }
@@ -80,12 +79,14 @@ higherBtn.addEventListener("click", function () {
     if (knownCardDrawn) {
         higherBtn.classList.add("selected");
         lowerBtn.classList.remove("selected");
+        unknownCard.classList.add("flippable");
     }
 });
 lowerBtn.addEventListener("click", function () {
     if (knownCardDrawn) {
         lowerBtn.classList.add("selected");
         higherBtn.classList.remove("selected");
+        unknownCard.classList.add("flippable");
     }
 });
 

--- a/style.css
+++ b/style.css
@@ -90,6 +90,48 @@ main div.game-board div.card.card-back {
     box-shadow: inset 0 0 0 2px rgb(245, 245, 245);
 }
 
+main div.game-board div.card.card-back:hover {
+    cursor: not-allowed;
+}
+
+main div.game-board div.card.flippable:not(:hover) {
+    animation: shake 5s infinite;
+}
+
+/* From [https://unused-css.com/blog/css-shake-animation/] */
+@keyframes shake {
+    0% {
+        transform: translateX(0);
+    }
+    80% {
+        transform: translateY(0) rotate(0);
+    }
+    85% {
+        transform: translateY(-9px);
+    }
+    87% {
+        transform: translateY(-9px) rotate(7deg);
+    }
+    91% {
+        transform: translateY(-9px) rotate(-7deg);
+    }
+    93% {
+        transform: translateY(-9px) rotate(7deg);
+    }
+    95% {
+        transform: translateY(-9px) rotate(-7deg);
+    }
+    100% {
+        transform: translateY(0) rotate(0);
+    }
+}
+
+main div.game-board div.card.flippable:hover {
+    border: solid 3px #d29603;
+    cursor: pointer;
+    transform: scale(1.1);
+}
+
 button {
     padding: 0.5rem 1.5rem;
     background-color: rgb(110, 0, 0);


### PR DESCRIPTION
### Description
This PR refactors the game's UI to be more interactive. It removes the old "Draw" button logic and replaces it with clickable cards.

* **CSS:** Adds a `.flippable` class to `style.css`. This class uses a `shake` animation to indicate to the player which card is currently interactive.
* **JS:**
    * A new click listener is added to the `known-card` element. When clicked, it reveals the first card, removes its own `.flippable` status, and activates the "High" / "Low" buttons.
    * The `higherBtn` and `lowerBtn` listeners are updated. In addition to toggling the `.selected` class, they now add the `.flippable` class to the `unknown-card`, signaling that it's the next element to be clicked.

### Related Issue
Closes #12 

### How to Test
1.  Load the `index.html` file.
2.  **Verify:** The first card (`known-card`) has the "shake" animation (`.flippable` class). The "High"/"Low" buttons are disabled (`.not-selectable`).
3.  Click the first card (`known-card`).
4.  **Verify:** The card "flips" (shows a value, `card-back` is removed). The shake animation stops. The "High"/"Low" buttons become active.
5.  Click the "High" button.
6.  **Verify:** The "High" button gets the `.selected` class, and the *second* card (`unknown-card`) now starts its "shake" animation (`.flippable` class).
7.  Click the "Low" button.
8.  **Verify:** The "High" button loses `.selected`, "Low" gains it, and the `unknown-card` continues to shake.