### PR TITLE
Bug: TypeError when clickin unknownCard when a Higher/Lower option is not selected

### DIFF
--- a/script.js
+++ b/script.js
@@ -137,9 +137,15 @@ lowerBtn.addEventListener("click", function () {
 
 // Reveal the unknown card
 unknownCard.addEventListener("click", function () {
+    // Check to see if a higher/lower option has been selected
+    const higherLowerSelected = document.querySelector(".selected");
+    if (higherLowerSelected == null) {
+        return;
+    }
+    // If a higher/lower select has been made, reveal the unknown card
     if (knownCardDrawn && !unknownCardDrawn) {
         // Get the player's guess based on which button is selected
-        let playerGuess = document.getElementsByClassName("selected")[0].id;
+        let playerGuess = higherLowerSelected.id;
         // Disable the ability for the player to change guesses after the reveal
         if (playerGuess === "higher-btn") {
             lowerBtn.classList.add("not-selectable");


### PR DESCRIPTION
### Description
This PR fixes a bug (Issue #24) that caused a `TypeError` if the user clicked the `unknown-card` before selecting 'High' or 'Low.'

The error `TypeError: Cannot read properties of undefined (reading 'id')` occurred because the code attempted to read the `.id` property from `document.getElementsByClassName("selected")[0]`, which was `undefined` when no button was selected.

The fix adds a **guard clause** to the beginning of the `unknownCard` event listener.
1.  It now uses `document.querySelector(".selected")` to find a selected button.
2.  If `higherLowerSelected` is `null` (meaning no guess was made), the function `return`s immediately.
3.  This prevents the code from reaching the line that caused the error and gracefully handles the invalid user action.

### Related Issue
Closes #24

### How to Test
1.  Load the `index.html` file.
2.  Click the first card (`known-card`) to reveal it.
3.  **Do not** click the "High" or "Low" buttons.
4.  Click the second, face-down card (`unknown-card`).
5.  **Verify:** The console no longer shows a `TypeError`. The game simply does nothing, waiting for the user to select a guess.
6.  *(Regression Test)*: Click the "High" button, then click the `unknown-card`.
7.  **Verify:** The game proceeds normally, confirming the fix did not break the standard game logic.