### PR TITLE
Feature: Implement Game Over on Incorrect Guess

### DIFF
--- a/script.js
+++ b/script.js
@@ -186,9 +186,7 @@ function convertCard(card) {
 }
 function compareCards(card1, card2, playerGuess) {
     let card1Value = convertCard(card1);
-    console.log(card1Value);
     let card2Value = convertCard(card2);
-    console.log(card2Value);
     if (
         (card1Value < card2Value && playerGuess === "higher-btn") ||
         (card1Value > card2Value && playerGuess === "lower-btn") ||
@@ -196,7 +194,9 @@ function compareCards(card1, card2, playerGuess) {
     ) {
         handleWin();
     } else {
-        console.log("You lose. Game Over.");
+        setTimeout(function () {
+            gameOverLose(streak);
+        }, 1000);
     }
 }
 
@@ -234,7 +234,9 @@ function handleWin() {
     }, 1000);
 }
 
-// Modal Functionality
+/*  MODAL FUNCTIONALITY
+    -------------------
+*/
 function showModal(contentHTML) {
     modalContent.innerHTML = contentHTML;
     modal.classList.remove("hidden");
@@ -244,7 +246,20 @@ function hideModal() {
     modalContent.innerHTML = "";
     modal.classList.add("hidden");
 }
-// Show Rules
+
+// Add an event listener for any buttons on the modal
+modal.addEventListener("click", function (event) {
+    if (event.target.id === "close-rules-btn") {
+        hideModal();
+    } else if (event.target.id === "game-over-btn") {
+        hideModal();
+        startNewGame();
+    }
+});
+
+/*  SHOW RULES MODAL
+    ----------------
+*/
 rulesBtn.addEventListener("click", function () {
     showModal(`<div id="show-rules-modal">
                     <div id="rules-header">
@@ -283,23 +298,34 @@ rulesBtn.addEventListener("click", function () {
                         </ul>
                         <p>Good luck!</p>
                     </div>
-                    <div id="rules-close-btn">
-                        <button id="close-rules">Close rules</button>
+                    <div id="modal-btn-row">
+                        <button id="close-rules-btn">Close rules</button>
                     </div>
                 </div>`);
 });
-// Add an event listener to the overlay to be able to use the button to close
-modal.addEventListener("click", function (event) {
-    if (event.target.id === "close-rules") {
-        hideModal();
-    }
-});
+
+/*  GAME OVER MODAL
+    ---------------
+*/
+function gameOverLose(score) {
+    showModal(`<div id="game-over-modal">
+                    <div id="modal-header">
+                        <h2>Game Over!</h2>
+                    </div>
+                    <div id="modal-text">
+                        <p id="game-over-modal-text">You got a streak of <span id="game-over-streak">${score}</span> this run! Try to beat it on the next one.</p>
+                    </div>
+                    <div id="modal-btn-row">
+                        <button id="game-over-btn">New Game</button>
+                    </div>
+                </div>`);
+}
 
 // Run the start new game function on page load
 startNewGame();
 
-/*  START EMOJI ROTATION
-    --------------------
+/*  EMOJI ROTATION FOOTER
+    ---------------------
     This feature is unrelated to the game logic. It cycles the emoji used in the footer of the
     page on page load and click
 */

--- a/style.css
+++ b/style.css
@@ -356,17 +356,35 @@ footer p span#footer-emoji {
     box-shadow: 0px 5px rgb(48, 48, 48);
 }
 
-#modal-content h2 {
+#modal-content h2,
+span#game-over-streak {
     font-family: "Jersey 10", sans-serif;
     font-size: 3rem;
     text-shadow: 0px 5px rgb(48, 48, 48);
     margin-bottom: 0;
     text-align: center;
 }
-#rules-header,
-#rules-close-btn {
+
+#game-over-modal-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+}
+
+span#game-over-streak {
+    padding-left: 5px;
+    color: #d29603;
+}
+
+#modal-header,
+#modal-btn-row {
     display: flex;
     justify-content: center;
+}
+
+#game-over-modal-text {
+    text-align: center;
 }
 
 .hidden {


### PR DESCRIPTION
### Description

This PR implements the "Game Over" screen using the reusable modal system. When a player loses, their game is stopped, and they are presented with their final score.

* **CSS:**
    * Adds styles for the "Game Over" modal, including `#modal-header`, `#modal-text`, and `#modal-btn-row`.
    * Uses `display: flex` and `align-items: center` on `#game-over-modal-text` to vertically align the text with the larger streak number.
    * Adds a custom color and padding to the `#game-over-streak` span to make it stand out.

* **JavaScript:**
    * Creates a new `gameOverLose(score)` function. This function generates the HTML for the "Game Over" modal (displaying the final `score`) and calls `showModal()`.
    * Updates the `compareCards` function: The `else` (lose) condition now calls `gameOverLose(streak)` inside a `setTimeout`. This 1-second delay improves game feel by allowing the player to see the losing card before the modal appears.
    * Updates the global `modal` click listener to handle the new `#game-over-btn`. Clicking this button now correctly calls `hideModal()` and `startNewGame()` to reset the board.

### Related Issue

Closes #21 

### How to Test

1.  Load the `index.html` file.
2.  Play a round and *intentionally lose* (e.g., reveal a 5, guess "Low," and then reveal a King).
3.  **Verify:** After the losing card (the King) is revealed, there is a short delay.
4.  **Verify:** The "Game Over!" modal appears, correctly displaying your final streak (e.g., "streak of 0").
5.  Click the "New Game" button inside the modal.
6.  **Verify:** The modal disappears, and the game board correctly resets to a new game.
7.  *(Regression Test)*: Click the "How to Play" button in the header.
8.  **Verify:** The rules modal still appears, and its "Close rules" button still works, confirming the event listener handles both cases.