### PR TITLE
Feature: Add Modal View for Discard and Active Piles

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,6 +4,8 @@ let unknownCardDrawn;
 let currentKnown;
 let currentUnknown;
 let streak;
+let canViewDiscardPile;
+let canViewActivePile;
 
 // Get various elements from game board
 const knownCard = document.getElementById("known-card");
@@ -27,6 +29,8 @@ function startNewGame() {
     currentUnknown = null;
     streak = 0;
     discardDeck = [];
+    canViewDiscardPile = false;
+    canViewActivePile = false;
     createDeck();
     shuffle(deck);
     knownCard.innerHTML = "";
@@ -184,6 +188,7 @@ function convertCard(card) {
     }
     return parseInt(card.split("-")[0]);
 }
+
 function compareCards(card1, card2, playerGuess) {
     let card1Value = convertCard(card1);
     let card2Value = convertCard(card2);
@@ -193,6 +198,9 @@ function compareCards(card1, card2, playerGuess) {
         card1Value === card2Value
     ) {
         handleWin();
+        // Check if discard pile is viewable
+
+        // Check in active pile is viewable
     } else {
         setTimeout(function () {
             gameOverLose(streak);
@@ -212,7 +220,6 @@ function handleWin() {
     knownCard.classList.add("slide-and-fade-out");
     setTimeout(function () {
         discardDeck.push(currentKnown);
-        discardPile.classList.remove("empty");
         unknownCard.classList.add("slide-and-replace");
         setTimeout(function () {
             currentKnown = currentUnknown;
@@ -230,9 +237,90 @@ function handleWin() {
             knownCardDrawn = true;
             unknownCardDrawn = false;
             currentUnknown = null;
+            // Temporary placeholder for testing
+            canViewDiscardPile = true;
+            canViewActivePile = true;
+            // Check whether the active/discard piles should be accessible or not
+            canAccessDiscardPile();
+            canAccessActivePile();
         }, 1000);
     }, 1000);
 }
+
+/*  VIEW DISCARD PILE
+    -----------------
+*/
+// Functions to handle pile access called after each round
+function canAccessDiscardPile() {
+    if (canViewDiscardPile) {
+        discardPile.classList.remove("inactive-pile");
+    } else {
+        discardPile.classList.add("inactive-pile");
+    }
+    if (discardDeck.length > 0) {
+        discardPile.classList.remove("empty");
+    } else {
+        discardPile.classList.add("empty");
+    }
+}
+function canAccessActivePile() {
+    if (canViewActivePile) {
+        activePile.classList.remove("inactive-pile");
+    } else {
+        activePile.classList.add("inactive-pile");
+    }
+    if (deck.length > 0) {
+        activePile.classList.remove("empty");
+    } else {
+        activePile.classList.add("empty");
+    }
+}
+
+discardPile.addEventListener("click", function () {
+    if (!canViewDiscardPile) {
+        return;
+    } else {
+        // For display pusposes, create a reversed COPY of the discard pile
+        const reverseDiscardDeck = [...discardDeck].reverse();
+        const cardsHTML = reverseDiscardDeck
+            .map((card) => `<div class="card"><h3>${card}</h3></div>`)
+            .join("");
+        showModal(`<div id="show-pile-modal">
+                        <div id="modal-header">
+                            <h2>Discard Pile</h2>
+                        </div>
+                        <div id="card-viewer-container" class="discard">
+                            ${cardsHTML}
+                        </div>
+                        <div id="modal-btn-row">
+                            <button id="close-modal-btn">Close</button>
+                        </div>
+                    </div>`);
+    }
+});
+
+activePile.addEventListener("click", function () {
+    if (!canViewActivePile) {
+        return;
+    } else {
+        // For display pusposes, create a reversed COPY of the discard pile
+        const reverseActiveDeck = [...deck].reverse();
+        const cardsHTML = reverseActiveDeck
+            .map((card) => `<div class="card"><h3>${card}</h3></div>`)
+            .join("");
+        showModal(`<div id="show-pile-modal">
+                        <div id="modal-header">
+                            <h2>Active Deck</h2>
+                        </div>
+                        <div id="card-viewer-container">
+                            ${cardsHTML}
+                        </div>
+                        <div id="modal-btn-row">
+                            <button id="close-modal-btn">Close</button>
+                        </div>
+                    </div>`);
+    }
+});
 
 /*  MODAL FUNCTIONALITY
     -------------------
@@ -249,7 +337,7 @@ function hideModal() {
 
 // Add an event listener for any buttons on the modal
 modal.addEventListener("click", function (event) {
-    if (event.target.id === "close-rules-btn") {
+    if (event.target.id === "close-modal-btn") {
         hideModal();
     } else if (event.target.id === "game-over-btn") {
         hideModal();
@@ -270,7 +358,7 @@ rulesBtn.addEventListener("click", function () {
                         <ul>
                             <li>
                                 Two cards are drawn from your deck. One is
-                                flipped. You must guess whther the card you
+                                flipped. You must guess if the card you
                                 cannot see is higher or lower than the one you
                                 can see.
                             </li>
@@ -281,7 +369,7 @@ rulesBtn.addEventListener("click", function () {
                             </li>
                             <li>
                                 When there are no more cards left in the deck to
-                                draw, the game is over. You have won 🎉
+                                draw, you have won 🎉
                             </li>
                             <li>
                                 As you play, you may be presented with modifiers
@@ -299,7 +387,7 @@ rulesBtn.addEventListener("click", function () {
                         <p>Good luck!</p>
                     </div>
                     <div id="modal-btn-row">
-                        <button id="close-rules-btn">Close rules</button>
+                        <button id="close-modal-btn">Close rules</button>
                     </div>
                 </div>`);
 });

--- a/style.css
+++ b/style.css
@@ -156,6 +156,27 @@ div.card {
     justify-content: center;
 }
 
+#card-viewer-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+    gap: 0.3rem;
+}
+#card-viewer-container::after {
+    content: "";
+    flex: auto;
+}
+
+#card-viewer-container.discard {
+    flex-direction: row-reverse;
+}
+
+#card-viewer-container div.card {
+    width: 3rem;
+    height: 4.2rem;
+    font-size: small;
+}
+
 main div.game-board div.card h3 {
     font-size: 2rem;
 }
@@ -356,25 +377,29 @@ footer p span#footer-emoji {
     box-shadow: 0px 5px rgb(48, 48, 48);
 }
 
-#modal-content h2,
-span#game-over-streak {
+#modal-content h2 {
     font-family: "Jersey 10", sans-serif;
     font-size: 3rem;
     text-shadow: 0px 5px rgb(48, 48, 48);
     margin-bottom: 0;
     text-align: center;
+    margin-top: 0;
 }
 
 #game-over-modal-text {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 5px;
 }
 
 span#game-over-streak {
+    font-family: "Jersey 10", sans-serif;
     padding-left: 5px;
     color: #d29603;
+    font-size: 3rem;
+    text-shadow: 0px 5px rgb(48, 48, 48);
+    margin-bottom: 0;
+    text-align: center;
 }
 
 #modal-header,
@@ -385,6 +410,19 @@ span#game-over-streak {
 
 #game-over-modal-text {
     text-align: center;
+    gap: 0.25rem;
+}
+
+#show-pile-modal,
+#game-over-modal,
+#show-rules-modal {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+}
+#show-pile-modal {
+    gap: 1rem;
 }
 
 .hidden {


### PR DESCRIPTION
### Description

This PR lays the foundation for the "Pile Viewer" modifier system. It adds the logic to check for player modifiers and display the contents of the `discardPile` and `activePile` in the modal viewer.

* **JavaScript:**
    * Adds placeholder variables (`canViewDiscardPile`, `canViewActivePile`) to `script.js` to simulate having modifiers.
    * Creates two new helper functions, `canAccessDiscardPile()` and `canAccessActivePile()`. These functions check for modifiers and deck length to toggle the `.inactive-pile` and `.empty` classes on the pile elements.
    * These helper functions are now called at the end of `handleWin()` and `startNewGame()` to ensure the pile UI is always correct.
    * Adds new click listeners to the `discardPile` and `activePile` elements.
    * If the player has the correct modifier, clicking a pile now:
        1.  Creates a **safe, reversed copy** of the deck array (`[...deck].reverse()`) to avoid breaking the game logic while ensuring correct display order.
        2.  Maps this array to an HTML string of "mini-cards."
        3.  Calls `showModal()` to display the cards in a new scrollable container (`#card-viewer-container`).
    * **Refactors the main modal event listener** to be more efficient. It now uses `else if` to handle all modal close buttons (`#close-modal-btn`, `#game-over-btn`) in one place.

* **CSS:**
    * Adds styling for the `#card-viewer-container` inside the modal, making it a `flex` grid.
    * Adds styles for the "mini-cards" inside the modal, making them smaller than the main game cards.
    * Uses a `.discard` class to apply `flex-direction: row-reverse` *only* to the discard pile viewer, ensuring the newest cards appear on the right.

### Related Issue

Closes #29

### How to Test

1.  *(Assumes `canViewDiscardPile` is set to `true` in `script.js` for testing)*
2.  Load `index.html` and play one round (reveal a card, guess, reveal the next).
3.  Click the "Discard Pile" (`#discard-pile`).
4.  **Verify:** The modal appears showing the one discarded card. The newest card (the first one discarded) should be on the far-right of the top row.
5.  Click the "Close" button.
6.  **Verify:** The modal closes (confirming the new `close-modal-btn` logic works).
7.  Click the "Active Pile" (`#active-pile`).
8.  **Verify:** The modal appears, showing all remaining cards in the deck. The *next* card to be drawn should be on the far-left of the top row.