### PR TITLE
Feature: Refactor 'showModifierSelection()' to use Modifier Bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                     <h2>Choose Modifier!</h2>
                     <button id="close-modifier-btn">No thanks...</button>
                 </div>
-                <div id="modifier-choices-container">...</div>
+                <div id="modifier-choices-container"></div>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -20,6 +20,11 @@ const activePile = document.getElementById("active-cards");
 const modal = document.getElementById("modal-overlay");
 const rulesBtn = document.getElementById("rules-btn");
 const modalContent = document.getElementById("modal-content");
+const modifierDrawer = document.getElementById("modifier-drawer");
+const modifierCloseBtn = document.getElementById("close-modifier-btn");
+const modifierChoicesContainer = document.getElementById(
+    "modifier-choices-container"
+);
 
 // A function to start a new game (called automatically on page load)
 function startNewGame() {
@@ -50,6 +55,7 @@ function startNewGame() {
     activePile.classList.add("inactive-pile");
     knownCard.classList.remove("slide-and-fade-out");
     unknownCard.classList.remove("slide-and-replace");
+    modifierDrawer.classList.remove("is-visible");
 }
 
 newGameBtn.addEventListener("click", function () {
@@ -559,7 +565,7 @@ const MODIFIER_LIBRARY = [
         title: "Trump Suit: ♥️",
         description:
             "Any heart card for the next round is higher than any non-heart card, regardless of rank.",
-        type: "instant",
+        type: "round",
         effect: "applyTrumpHearts",
         image: "level-up",
         weight: 2, // rare
@@ -569,7 +575,7 @@ const MODIFIER_LIBRARY = [
         title: "Trump Suit: ♦️",
         description:
             "Any diamond card for the next round is higher than any non-diamond card, regardless of rank.",
-        type: "instant",
+        type: "round",
         effect: "applyTrumpDiamonds",
         image: "level-up",
         weight: 2, // rare
@@ -579,7 +585,7 @@ const MODIFIER_LIBRARY = [
         title: "Trump Suit: ♣️",
         description:
             "Any club card for the next round is higher than any non-club card, regardless of rank.",
-        type: "instant",
+        type: "round",
         effect: "applyTrumpClubs",
         image: "level-up",
         weight: 2, // rare
@@ -589,7 +595,7 @@ const MODIFIER_LIBRARY = [
         title: "Trump Suit: ♠️",
         description:
             "Any spade card for the next round is higher than any non-spade card, regardless of rank.",
-        type: "instant",
+        type: "round",
         effect: "applyTrumpSpades",
         image: "level-up",
         weight: 2, // rare
@@ -614,24 +620,14 @@ function showModifierSelection() {
                     <img src="images/${choice.image}.png" alt="${choice.title}">
                     <h3>${choice.title}</h3>
                     <p class="rarity-label">${rarity.label}</p>
-                    <p>${choice.description}</p>
                 </button>
                 `;
         })
         .join("");
-    showModal(`
-        <div id="modifier-selection-modal">
-            <div id="modal-header">
-                <h2>Choose a Modifier!</h2>
-            </div>
-            <div id="modifier-choices-container">
+    modifierChoicesContainer.innerHTML = `
             ${modifiersHTML}
-            </div>
-            <div id="modal-btn-row">
-                <button id="close-modal-btn">No thanks...</button>
-            </div>
-        </div>
-        `);
+        `;
+    modifierDrawer.classList.add("is-visible");
 }
 function getRandomModifier() {
     let totalWeight = 0;
@@ -755,8 +751,6 @@ function applySwapWithActive() {
 
 // temp
 const showModifiers = document.getElementById("show-modifiers");
-const modifierDrawer = document.getElementById("modifier-drawer");
-const modifierCloseBtn = document.getElementById("close-modifier-btn");
 showModifiers.addEventListener("click", function () {
     modifierDrawer.classList.add("is-visible");
 });

--- a/style.css
+++ b/style.css
@@ -444,11 +444,13 @@ span#game-over-streak {
     padding: 2rem;
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: no-wrap;
     justify-content: space-between;
     align-items: center;
     height: auto;
     max-width: 600px;
+    margin: auto;
+    gap: 2rem;
 }
 #modifier-header {
     max-width: 125px;
@@ -496,7 +498,8 @@ span#game-over-streak {
 }
 
 .modifier-choice {
-    padding: 1rem;
+    padding: 0.5rem;
+    width: 8rem;
 }
 
 .modifier-choice img {
@@ -506,7 +509,7 @@ span#game-over-streak {
 
 .modifier-choice h3 {
     font-family: "Jersey 10", sans-serif;
-    font-size: 2rem;
+    font-size: 1.5rem;
     text-shadow: 0px 5px rgb(48, 48, 48);
     margin-bottom: 0;
     text-align: center;
@@ -514,7 +517,7 @@ span#game-over-streak {
 }
 .modifier-choice p {
     font-weight: 400;
-    font-size: 0.75rem;
+    font-size: 0.6rem;
 }
 
 #modifier-choices-container {
@@ -530,10 +533,11 @@ span#game-over-streak {
     border-radius: 50px;
     text-transform: uppercase;
     font-style: italic;
-    padding: 0.5rem 0.25rem;
+    padding: 0.25rem;
     box-shadow: 0px 5px rgb(48, 48, 48);
-    margin-left: 1rem;
-    margin-right: 1rem;
+    margin-left: 0.75rem;
+    margin-right: 0.75rem;
+    font-size: 0.5rem;
 }
 .modifier-choice.rarity-common {
     background-color: rgb(69, 69, 69);


### PR DESCRIPTION
### Description

This PR refactors the "Choose a Modifier" screen (Issue #28) to use the new "Modifier Drawer" UI (built in Issue #44). This moves the modifier selection from a blocking, full-screen modal to the new non-intrusive, slide-down panel, allowing the player to see the game board while making a choice.

* **JavaScript (`script.js`):**
    * The `showModifierSelection()` function has been refactored.
    * It no longer calls `showModal()`.
    * Instead, it generates the `modifiersHTML` string (now without the `<p>` description, to fit the new layout).
    * It injects this HTML string into the `modifierChoicesContainer.innerHTML`.
    * It triggers the slide-down animation by adding the `.is-visible` class to the `modifierDrawer` element.

### Related Issue

Closes #45

### How to Test

1.  Load the `index.html` file.
2.  Play and **win** one round of the game.
3.  **Verify:** The old full-screen modal *does not* appear.
4.  **Verify:** The new `#modifier-drawer` slides down from the top of the screen, showing the three modifier choices.
5.  **Verify:** The choices are displayed correctly without their descriptions, and the "No thanks..." button is visible in the drawer.
6.  *(Test for next issue)*: Clicking the buttons won't do anything yet, as the new event listener (Issue #46) hasn't been added.