### PR TITLE
Bug: Modifier choice clicks don't work after UI refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
             <div id="game-buttons">
                 <button id="new-game-btn">New Game</button>
                 <button id="rules-btn">How to Play</button>
-                <button id="show-modifiers">👀</button>
             </div>
         </header>
         <main>

--- a/style.css
+++ b/style.css
@@ -328,7 +328,7 @@ button.selected {
     opacity: 0.5;
 }
 
-#deck-area div.card-pile.inactive-pile {
+.inactive-pile {
     filter: grayscale();
 }
 
@@ -503,8 +503,8 @@ span#game-over-streak {
 }
 
 .modifier-choice img {
-    width: 64px;
-    height: 64px;
+    width: 48px;
+    height: 48px;
 }
 
 .modifier-choice h3 {


### PR DESCRIPTION
### Description

This PR fixes a bug (Issue #46) where the game was still playable while the modifier drawer was open. It also completes the UI refactor by hooking up the drawer's event listeners.

* **JavaScript Refactor (`script.js`):**
    * Creates a new helper function, `hideModifierBar()`, which removes the `.is-visible` class (triggering the slide-up animation) and clears the drawer's `innerHTML` after a delay.
    * Updates the `applyModifier()` function to call `hideModifierBar()` instead of `hideModal()`.
    * Adds a **new event listener** for the `#modifier-drawer`. This listener uses event delegation to:
        * Handle clicks on `.modifier-choice` buttons, read the `data-modifier-id`, and call `applyModifier()`.
        * Handle clicks on the `#close-modifier-btn`, calling `hideModifierBar()`.

* **Game Pause/Resume Logic:**
    * Adds a new global state variable, `let isGamePaused = false;`.
    * Creates `pauseGame()` and `resumeGame()` functions. These functions toggle the `isGamePaused` state and update UI classes (like `.flippable` and `.not-selectable`) to make the board look active or inactive.
    * `pauseGame()` is now called by `showModifierSelection()`.
    * `resumeGame()` is called by `hideModifierBar()`.
    * **Guard clauses** (`if (isGamePaused) return;`) have been added to the top of all gameplay-related event listeners (`higherBtn`, `lowerBtn`, `knownCard`, `unknownCard`, `discardPile`, `activePile`). This ensures the game logic is truly paused and no clicks are registered while the drawer is open.

### Related Issues

Closes #46 

### How to Test

1.  Load `index.html`.
2.  Play and **win** one round.
3.  **Verify:** The modifier drawer slides down from the top.
4.  **Test Pause State:** While the drawer is open, try to click the game cards, the "Higher/Lower" buttons, and the discard/active piles.
5.  **Verify:** Nothing happens. The game is correctly paused, and no actions can be taken (this confirms the `isGamePaused` guard clauses are working).
6.  Open the developer console.
7.  Click on a modifier choice in the drawer.
8.  **Verify:** The console logs the correct `modifierId`, the drawer slides up, and the game board becomes interactive again (this confirms `applyModifier` and `resumeGame` were called).
9.  Win another round. When the drawer appears, click the "No thanks..." button.
10. **Verify:** The drawer slides up, and the game board becomes interactive again (this confirms the `#close-modifier-btn` listener and `resumeGame` were called).