### PR TITLE
Feature: Implement "Round" Modifier System and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,10 @@
                     <h3>Streak:</h3>
                     <p id="streak-count-num">0!</p>
                 </div>
-                <div id="modifiers"></div>
+                <div id="modifiers">
+                    <div id="game-modifers"></div>
+                    <div id="round-modifiers"></div>
+                </div>
             </div>
             <div class="game-board pixel-corners">
                 <div class="card-row">

--- a/style.css
+++ b/style.css
@@ -44,6 +44,11 @@ header h1 {
     margin-top: 1rem;
     margin-bottom: 0;
 }
+@media (width <= 530px) {
+    header h1 {
+        font-size: 3rem;
+    }
+}
 
 header h1 span.emoji {
     font-size: 3rem;
@@ -476,7 +481,7 @@ span#game-over-streak {
     transform: translate(0);
 }
 
-.modifier-choice:hover {
+.modifier-choice:not(.active-modifier-pin):hover {
     animation: bounce 2s infinite ease-in-out;
 }
 @keyframes bounce {
@@ -576,6 +581,26 @@ span#game-over-streak {
     color: #d29603;
 }
 
+#modifiers {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.active-modifier-pin {
+    border-radius: 50px;
+    width: 56px;
+    height: 56px;
+    display: flex;
+    margin: auto;
+    justify-content: center;
+    align-items: center;
+}
+.active-modifier-pin img {
+    width: 32px;
+    height: 32px;
+}
+
 #modifier-tooltip {
     position: fixed;
     display: none;
@@ -587,6 +612,10 @@ span#game-over-streak {
     line-height: 1rem;
     font-size: 1rem;
     transform: translateX(-50%);
+}
+
+#modifier-tooltip.is-above {
+    transform: translateX(-50%) translateY(-100%);
 }
 
 /* START PIXEL CORNERS */


### PR DESCRIPTION
### Description

This PR implements a major new feature: the distinction between "Instant" and "Round" modifiers. This adds a new layer of strategy by allowing some effects (like "Trump Suit") to persist for an entire round.

* **Game State:**
    * Adds a new global array, `let activeRoundModifiers = [];`, to track which modifiers are active for the current round.

* **JavaScript Logic (`script.js`):**
    * **`applyModifier(id)` Refactor:** This function now finds the *full* modifier object using `MODIFIER_LIBRARY.find()`.
    * It now checks `modifier.type`. If `"instant"`, it calls the effect function as normal. If `"round"`, it pushes the entire modifier object into the `activeRoundModifiers` array.
    * **`updateActiveModifierUI()`:** A new function that reads the `activeRoundModifiers` array and generates HTML for the active modifier icons (reusing the `.modifier-choice` class). This HTML is injected into the `#round-modifiers` div.
    * **`compareCards()` Refactor:** At the very end of this function (after a win or loss), it now clears the `activeRoundModifiers = [];` array and calls `updateActiveModifierUI()` to remove the icons, ensuring they only last for one round.

* **Tooltip UI:**
    * **CSS:** Adds a new `.is-above` class to `style.css`. This class uses `transform: translateY(-100%)` to shift the tooltip and position it *above* an element.
    * **JS:** Adds a new `mouseover` listener for the `#round-modifiers` container.
    * This listener adds the `.is-above` class to the tooltip and uses `rect.top` to position it directly above the hovered icon, preventing it from covering the game board.
    * The `modifierChoicesContainer`'s `mouseover` listener is updated to *remove* the `.is-above` class, ensuring the tooltip still appears *below* the selection buttons.

### Related Issue

Closes #52 

### How to Test

1.  Load the `index.html` file.
2.  Play and win a round.
3.  Select an **"Instant"** modifier (e.g., "+1 Value Boost").
4.  **Verify:** The modifier applies, the drawer closes, and *no icon* appears in the `#round-modifiers` div.
5.  Play and win another round.
6.  Select a **"Round"** modifier (e.g., "Trump Suit: ♥️").
7.  **Verify:** The drawer closes, and the "♥️" icon *does* appear in the `#round-modifiers` div.
8.  Hover your mouse over the new "♥️" icon.
9.  **Verify:** The tooltip appears *above* the icon, displaying the correct description.
10. Play the next round (win or lose).
11. **Verify:** As soon as the round ends, the "♥️" icon disappears from the `#round-modifiers` div, confirming the cleanup in `compareCards()` worked.