### PR TITLE
Feature: Set Base Modifier Choices to 2

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ let activeTrumpSuit;
 let isGamePaused;
 let activeRoundModifiers;
 let isFaceCardOrderAlphabetical;
+let modifierChoicesCount;
 
 // Get various elements from game board
 const knownCard = document.getElementById("known-card");
@@ -46,6 +47,7 @@ function startNewGame() {
     isGamePaused = false;
     activeRoundModifiers = [];
     isFaceCardOrderAlphabetical = false;
+    modifierChoicesCount = 2;
     createDeck();
     shuffle(deck);
     knownCard.innerHTML = "";
@@ -671,16 +673,16 @@ const MODIFIER_LIBRARY = [
     },
 ];
 function showModifierSelection() {
-    const choice1 = getRandomModifier();
-    let choice2 = getRandomModifier();
-    let choice3 = getRandomModifier();
-    while (choice2.id === choice1.id) {
-        choice2 = getRandomModifier();
+    let choices = [];
+    while (choices.length < modifierChoicesCount) {
+        const newChoice = getRandomModifier();
+        const isAlreadyChosen = choices.some(
+            (choice) => choice.id === newChoice.id
+        );
+        if (!isAlreadyChosen) {
+            choices.push(newChoice);
+        }
     }
-    while (choice3.id === choice1.id || choice3.id === choice2.id) {
-        choice3 = getRandomModifier();
-    }
-    const choices = [choice1, choice2, choice3];
     const modifiersHTML = choices
         .map((choice) => {
             const rarity = getRarityTier(choice.weight);


### PR DESCRIPTION
### Description

This PR refactors the modifier selection logic to make the number of choices dynamic (Issue #55). The default number of modifier choices is now set to 2, which establishes a baseline for the game and allows for future perks that can increase this count.

* **Game State:**
    * Adds a new global variable, `let modifierChoicesCount = 2;`, to `script.js`.
    * Updates the `startNewGame()` function to reset `modifierChoicesCount = 2;` at the start of every game.

* **JavaScript Refactor:**
    * The `showModifierSelection()` function is updated.
    * It no longer uses hard-coded `choice1, choice2, choice3` variables.
    * It now uses a `while (choices.length < modifierChoicesCount)` loop to build a `choices` array.
    * Inside the loop, it correctly calls `getRandomModifier()` and uses `choices.some()` to ensure the selected modifiers are unique before pushing them to the array.

### Related Issue

Closes #55

### How to Test

1.  Load the `index.html` file.
2.  Play and **win** one round of the game.
3.  **Verify:** The modifier drawer slides down and now displays only **two** modifier choices.
4.  Click "New Game" and win another round.
5.  **Verify:** The drawer again displays only two choices, confirming the `startNewGame` reset logic is working.
6.  *(Visual Check)*: Confirm that the modifier drawer layout (`#modifier-choices-container`) still looks good with two items instead of three.